### PR TITLE
squid:S2864 - "entrySet()" should be iterated when both the key and v…

### DIFF
--- a/jar/src/main/java/org/mobicents/tools/sip/balancer/CallIDAffinityBalancerAlgorithm.java
+++ b/jar/src/main/java/org/mobicents/tools/sip/balancer/CallIDAffinityBalancerAlgorithm.java
@@ -26,6 +26,7 @@ import gov.nist.javax.sip.header.SIPHeader;
 import gov.nist.javax.sip.header.Via;
 
 import java.util.ArrayList;
+import java.util.Map;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Timer;
@@ -239,11 +240,11 @@ public class CallIDAffinityBalancerAlgorithm extends DefaultBalancerAlgorithm {
 		
 		int minUtil = Integer.MAX_VALUE;
 		SIPNode minUtilNode = null;
-		for(SIPNode node : nodeUtilization.keySet()) {
-			Integer util = nodeUtilization.get(node);
-			if(!node.equals(deadNode) && (util < minUtil)) {
+		for(Map.Entry<SIPNode, Integer> entry : nodeUtilization.entrySet()) {
+			Integer util = entry.getValue();
+			if(!entry.getKey().equals(deadNode) && (util < minUtil)) {
 				minUtil = util;
-				minUtilNode = node;
+				minUtilNode = entry.getKey();
 			}
 		}
 
@@ -321,10 +322,10 @@ public class CallIDAffinityBalancerAlgorithm extends DefaultBalancerAlgorithm {
 			SIPNode newNode = getBalancerContext().jvmRouteToSipNode.get(toJvmRoute);
 			if(oldNode != null && newNode != null) {
 				int updatedRoutes = 0;
-				for(String key : callIdMap.keySet()) {
-					SIPNode n = callIdMap.get(key);
+				for(Map.Entry<String, SIPNode> entry : callIdMap.entrySet()) {
+					SIPNode n = entry.getValue();
 					if(n.equals(oldNode)) {
-						callIdMap.replace(key, newNode);
+						callIdMap.replace( entry.getKey(), newNode);
 						updatedRoutes++;
 					}
 				}
@@ -349,10 +350,10 @@ public class CallIDAffinityBalancerAlgorithm extends DefaultBalancerAlgorithm {
 		try {
 			if(oldNode != null && newNode != null) {
 				int updatedRoutes = 0;
-				for(String key : callIdMap.keySet()) {
-					SIPNode n = callIdMap.get(key);
+				for(Map.Entry<String, SIPNode> entry : callIdMap.entrySet()) {
+					SIPNode n = entry.getValue();
 					if(n.equals(oldNode)) {
-						callIdMap.replace(key, newNode);
+						callIdMap.replace(entry.getKey(), newNode);
 						updatedRoutes++;
 					}
 				}

--- a/jar/src/main/java/org/mobicents/tools/sip/balancer/ClusterSubdomainAffinityAlgorithm.java
+++ b/jar/src/main/java/org/mobicents/tools/sip/balancer/ClusterSubdomainAffinityAlgorithm.java
@@ -24,6 +24,7 @@ package org.mobicents.tools.sip.balancer;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.log4j.Logger;
 
@@ -89,8 +90,8 @@ public class ClusterSubdomainAffinityAlgorithm extends CallIDAffinityBalancerAlg
 	
 	public String dumpSubcluster() {
 		String result = "";
-		for(String host:nodeToNodeGroup.keySet()) {
-			String mapped = host + ": " + nodeToNodeGroup.get(host);
+		for(Map.Entry<String, List<String>> entry : nodeToNodeGroup.entrySet()) {
+			String mapped = entry.getKey() + ": " + entry.getValue();
 			result += mapped + "\n";
 		}
 		return result;

--- a/jar/src/main/java/org/mobicents/tools/sip/balancer/UserBasedAlgorithm.java
+++ b/jar/src/main/java/org/mobicents/tools/sip/balancer/UserBasedAlgorithm.java
@@ -22,6 +22,7 @@ package org.mobicents.tools.sip.balancer;
 import gov.nist.javax.sip.header.Via;
 
 import java.util.ArrayList;
+import java.util.Map;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Timer;
@@ -275,10 +276,10 @@ public class UserBasedAlgorithm extends DefaultBalancerAlgorithm {
 			SIPNode newNode = getBalancerContext().jvmRouteToSipNode.get(toJvmRoute);
 			if(oldNode != null && newNode != null) {
 				int updatedRoutes = 0;
-				for(String key : userToMap.keySet()) {
-					SIPNode n = userToMap.get(key);
+				for( Map.Entry<String, SIPNode> entry : userToMap.entrySet() ) {
+					SIPNode n = entry.getValue();
 					if(n.equals(oldNode)) {
-						userToMap.replace(key, newNode);
+						userToMap.replace( entry.getKey(), newNode);
 						updatedRoutes++;
 					}
 				}
@@ -346,11 +347,11 @@ public class UserBasedAlgorithm extends DefaultBalancerAlgorithm {
 		}
 		int minUtil = Integer.MAX_VALUE;
 		SIPNode minUtilNode = null;
-		for(SIPNode node : nodeUtilization.keySet()) {
-			Integer util = nodeUtilization.get(node);
-			if(!node.equals(deadNode) && (util < minUtil)) {
+		for(Map.Entry<SIPNode, Integer> entry : nodeUtilization.entrySet()) {
+			Integer util = entry.getValue();
+			if(!entry.getKey().equals(deadNode) && (util < minUtil)) {
 				minUtil = util;
-				minUtilNode = node;
+				minUtilNode = entry.getKey();
 			}
 		}
 
@@ -369,10 +370,10 @@ public class UserBasedAlgorithm extends DefaultBalancerAlgorithm {
 		try {
 			if(oldNode != null && newNode != null) {
 				int updatedRoutes = 0;
-				for(String key : userToMap.keySet()) {
-					SIPNode n = userToMap.get(key);
+				for(Map.Entry<String, SIPNode> entry : userToMap.entrySet() ) {
+					SIPNode n = entry.getValue();
 					if(n.equals(oldNode)) {
-						userToMap.replace(key, newNode);
+						userToMap.replace( entry.getKey(), newNode);
 						updatedRoutes++;
 					}
 				}

--- a/jar/src/main/java/org/mobicents/tools/sip/balancer/WorstCaseUdpTestAffinityAlgorithm.java
+++ b/jar/src/main/java/org/mobicents/tools/sip/balancer/WorstCaseUdpTestAffinityAlgorithm.java
@@ -27,6 +27,7 @@ import gov.nist.javax.sip.header.Via;
 
 import java.text.ParseException;
 import java.util.ArrayList;
+import java.util.Map;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Timer;
@@ -292,11 +293,11 @@ public class WorstCaseUdpTestAffinityAlgorithm extends DefaultBalancerAlgorithm 
 		
 		int minUtil = Integer.MAX_VALUE;
 		SIPNode minUtilNode = null;
-		for(SIPNode node : nodeUtilization.keySet()) {
-			Integer util = nodeUtilization.get(node);
-			if(!node.equals(deadNode) && (util < minUtil)) {
+		for(Map.Entry<SIPNode, Integer> entry : nodeUtilization.entrySet()) {
+			Integer util = entry.getValue();
+			if(!entry.getKey().equals(deadNode) && (util < minUtil)) {
 				minUtil = util;
-				minUtilNode = node;
+				minUtilNode = entry.getKey();
 			}
 		}
 
@@ -384,10 +385,10 @@ public class WorstCaseUdpTestAffinityAlgorithm extends DefaultBalancerAlgorithm 
 			SIPNode newNode = getBalancerContext().jvmRouteToSipNode.get(toJvmRoute);
 			if(oldNode != null && newNode != null) {
 				int updatedRoutes = 0;
-				for(String key : callIdMap.keySet()) {
-					SIPNode n = callIdMap.get(key);
+				for(Map.Entry<String, SIPNode> entry : callIdMap.entrySet()) {
+					SIPNode n = entry.getValue();
 					if(n.equals(oldNode)) {
-						callIdMap.replace(key, newNode);
+						callIdMap.replace( entry.getKey(), newNode);
 						updatedRoutes++;
 					}
 				}
@@ -412,10 +413,10 @@ public class WorstCaseUdpTestAffinityAlgorithm extends DefaultBalancerAlgorithm 
 		try {
 			if(oldNode != null && newNode != null) {
 				int updatedRoutes = 0;
-				for(String key : callIdMap.keySet()) {
-					SIPNode n = callIdMap.get(key);
+				for(Map.Entry<String, SIPNode> entry : callIdMap.entrySet() ) {
+					SIPNode n = entry.getValue();
 					if(n.equals(oldNode)) {
-						callIdMap.replace(key, newNode);
+						callIdMap.replace( entry.getKey(), newNode);
 						updatedRoutes++;
 					}
 				}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2864 - "entrySet()" should be iterated when both the key and value are needed

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2864

Please let me know if you have any questions.

M-Ezzat
